### PR TITLE
Fix - Warning: Cannot send session cookie

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -1,4 +1,7 @@
 <?php
+// create/read session, absolutely necessary
+@ob_start();
+session_start();
 
 /**
  * Class login
@@ -25,9 +28,6 @@ class Login
      */
     public function __construct()
     {
-        // create/read session, absolutely necessary
-        session_start();
-
         // check the possible login actions:
         // if user tried to log out (happen when user clicks logout button)
         if (isset($_GET["logout"])) {


### PR DESCRIPTION
The following warning comes in login page: Its working in localhost but not in remote host.
https://stackoverflow.com/questions/21521768/warning-session-start-cannot-send-session-cookie-headers-already-sent-by